### PR TITLE
fix: infinitive loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /ignore
 /output
 .env
+.idea/

--- a/processor.go
+++ b/processor.go
@@ -60,7 +60,7 @@ func (p *Processor) Members(orgName string) ([]string, error) {
 			result = append(result, *member.Login)
 		}
 
-		if currentPage == response.LastPage {
+		if response.NextPage == 0 {
 			break
 		}
 
@@ -122,7 +122,7 @@ func (p *Processor) getTeamsPaginated(orgName string) ([]*github.Team, error) {
 
 		allTeams = append(allTeams, teams...)
 
-		if currentPage == response.LastPage {
+		if response.NextPage == 0 {
 			break
 		}
 
@@ -154,7 +154,7 @@ func (p *Processor) getTeamMembersPaginated(orgID int64, team *github.Team) ([]*
 
 		allMembers = append(allMembers, members...)
 
-		if currentPage == response.LastPage {
+		if response.NextPage == 0 {
 			break
 		}
 


### PR DESCRIPTION
GitHub doesn't include rel="last" in the Link header when you're on the last page, so response.LastPage becomes 0. But currentPage is already, say, 3 — so 3 == 0 is false, you never break, and currentPage = response.NextPage resets to 0, causing an infinite loop.